### PR TITLE
need to actually build dist on publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+src/
+test/
+nyc.config.js

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Encode hidden data within NaN IEEE 754 floats",
   "scripts": {
     "build": "babel src -d dist",
+    "prepublish": "npm run build",
     "lint": "eslint .",
     "release": "np",
     "test": "nyc ava"
   },
+  "main": "./dist/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/philihp/nanbox.git"


### PR DESCRIPTION
* .npmignore should not include tests or source.
* prepublish should build `dist`
* package.json should point to `dist/index.js`